### PR TITLE
Add !giveaway Command

### DIFF
--- a/messages.py
+++ b/messages.py
@@ -2,7 +2,7 @@ from beam import Beam
 from models import (Command, User, session, CommandCommand, QuoteCommand,
                     CubeCommand, SocialCommand, UptimeCommand, PointsCommand,
                     TemmieCommand, FriendCommand, SpamProtCommand, ProCommand,
-                    SubCommand)
+                    SubCommand, GiveawayCommand)
 from asyncio import async, coroutine
 from functools import partial
 from re import findall
@@ -32,8 +32,8 @@ class MessageHandler(Beam):
             "pro": ProCommand(),
             "sub": SubCommand(),
             "cube": CubeCommand(),
-            "temmie": TemmieCommand()
-            "quirkytest": QuirkyTest()
+            "temmie": TemmieCommand(),
+            "giveaway": GiveawayCommand()
         }
 
     def handle(self, response):

--- a/messages.py
+++ b/messages.py
@@ -33,6 +33,7 @@ class MessageHandler(Beam):
             "sub": SubCommand(),
             "cube": CubeCommand(),
             "temmie": TemmieCommand()
+            "quirkytest": QuirkyTest()
         }
 
     def handle(self, response):

--- a/models.py
+++ b/models.py
@@ -347,14 +347,12 @@ class GiveawayCommand(Command):
             return ""
         if self.wait_time == 0:
             is_running = False
-            print(len(self.candidates))
             if len(self.candidates) == 0:
                 return "Nobody joined the giveaway..."
             else:
                 return "@{} has won the giveaway!".format(
                 choice(self.candidates))
         self.wait_time = int(self.wait_time) - 1
-        print(self.wait_time)
         if self.wait_time in [30, 10, 3, 2, 1]:
             return("Giveaway ends in {} seconds!".format(self.wait_time))
 
@@ -366,7 +364,6 @@ class GiveawayCommand(Command):
                 if data["user_name"] in self.candidates:
                     return "You have already entered!"
                 else:
-                    print(self.candidates)
                     self.candidates.append(data["user_name"])
                     return "@{} You have entered the giveaway!".format(
                     data["user_name"])
@@ -396,7 +393,6 @@ class GiveawayCommand(Command):
                 if self.is_running:
                     self.wait_time = -1
                     self.is_running = False
-                    print(len(self.candidates))
                     if len(self.candidates) == 0:
                         return "Nobody joined the giveaway..."
                     else:

--- a/models.py
+++ b/models.py
@@ -402,3 +402,13 @@ class GiveawayCommand(Command):
                     return "No giveaway is currently running!"
             else:
                 return "This command is Mod-only!"
+        elif args[1].lower() == "cancel":
+            if any(filter(lambda role: role in data["user_roles"],
+            ["Founder", "Staff", "Global Mod", "Mod", "Owner"])):
+                if self.is_running:
+                    self.wait_time = -1
+                    return "Giveaway cancelled."
+                else:
+                    return "No giveaway is currently running!"
+            else:
+                return "This command is Mod-only!"

--- a/models.py
+++ b/models.py
@@ -245,7 +245,7 @@ class PointsCommand(Command):
             name=self.points_name + ('s' if user.points != 1 else ''))
 
 class QuirkyTest(Command)
-    def _init_(self, args=None, data=None):
+    def __call__(self, args=None, data=None):
         return "Hai! This is a command!"
 
 class TemmieCommand(Command):

--- a/models.py
+++ b/models.py
@@ -244,6 +244,9 @@ class PointsCommand(Command):
             amount=user.points,
             name=self.points_name + ('s' if user.points != 1 else ''))
 
+class QuirkyTest(Command)
+    def _init_(self, args=None, data=None):
+        return "Hai! This is a command!"
 
 class TemmieCommand(Command):
     quotes = [

--- a/models.py
+++ b/models.py
@@ -244,10 +244,6 @@ class PointsCommand(Command):
             amount=user.points,
             name=self.points_name + ('s' if user.points != 1 else ''))
 
-class QuirkyTest(Command)
-    def __call__(self, args=None, data=None):
-        return "Hai! This is a command!"
-
 class TemmieCommand(Command):
     quotes = [
         "fhsdhjfdsfjsddshjfsd",


### PR DESCRIPTION
Giveaways in streams can be difficult when people are afk/don't want the item/are bots, so this command would streamline it to run the giveaway just once. 

USAGE:
!giveaway start [time] (Mod-Only) ----- Starts the giveaway countdown for a certain time, defaults to 60
!giveaway join -------------------------- Join the giveaway while it is counting down
!giveaway end (Mod-Only) ------------ Stops the countdown and picks a winner.
!giveaway cancel (Mod-Only) --------- Cancels the giveaway without picking a winner.

There are probably some ways to make it work more efficiently, as I am a skrub and I'm not that good at programming, but it works.