### PR TITLE
Fixed !multi not responding when run incorrectly

### DIFF
--- a/cactusbot/commands/magic/multi.py
+++ b/cactusbot/commands/magic/multi.py
@@ -25,7 +25,8 @@ class Multi(Command):
         for channel in channels:
             split = channel.split(':')
             if len(split) < 2:
-                return "'{}' must be in <service>:<username> form!".format(channel)
+                return "'{}' must be in <service>:<username> " \
+                       "form!".format(channel)
             else:
                 service = split[0]
                 channel_name = split[1]

--- a/cactusbot/commands/magic/multi.py
+++ b/cactusbot/commands/magic/multi.py
@@ -23,7 +23,12 @@ class Multi(Command):
         link = _BASE_URL
 
         for channel in channels:
-            service, channel_name = channel.split(':')
+            split = channel.split(':')
+            if len(split) < 2:
+                return "'{}' must be in <service>:<username> form!".format(channel)
+            else:
+                service = split[0]
+                channel_name = split[1]
 
             if service not in _SERVICES:
                 return "'{}' is not a valid service.".format(service)


### PR DESCRIPTION
## What does this change?
Previously running `!multi` without the proper format in the arguments (`!multi innectic` for example) would make the bot invisibly error and not return anything to the user. This resolves that and makes it easy to understand what went wrong.

## Requirements

 - [x] Only PG-rated language used (code, commits, etc.)
 - [x] Descriptive commit messages
 - [x] Changes have been tested
 - [x] Changes do not break any existing functionalities
