### PR TITLE
Added minor error catching for entry/leave announcements

### DIFF
--- a/cactusbot/handlers/events.py
+++ b/cactusbot/handlers/events.py
@@ -124,10 +124,13 @@ class EventHandler(Handler):
             }
 
     async def _cache(self, packet, event):
-        response = MessagePacket(
-            self.alert_messages[event]["message"].replace(
-                "%USER%", packet.user
-            ))
+        if hasattr(packet, "user"):
+            response = MessagePacket(
+                self.alert_messages[event]["message"].replace(
+                    "%USER%", packet.user
+                ))
+        else:
+            return None
 
         if packet.success:
             if self.cache_data["cache_{}".format(event)]:


### PR DESCRIPTION
## What does this change?
It adds a test to catch errors when announcement packets of user entries or departures from a stream's chat don't include the user attribute

## Requirements

 - [x] Only PG-rated language used (code, commits, etc.)
 - [x] Descriptive commit messages
 - [x] Changes have been tested
 - [x] Changes do not break any existing functionalities
