### PR TITLE
Add role changing for custom commands

### DIFF
--- a/cactusbot/api.py
+++ b/cactusbot/api.py
@@ -154,6 +154,12 @@ class Command(CactusAPIBucket):
             self.api.patch("/user/{token}/command/{command}/count".format(
                 token=self.api.token, command=command), data=json.dumps(data)))
 
+    async def update(self, command, value):
+        """Update command attributes."""
+
+        return await self.api.patch("/user/{token}/command/{command}".format(
+            token=self.api.token, command=command), data=json.dumps(value))
+
 
 class Alias(CactusAPIBucket):
     """CactusAPI /alias bucket."""

--- a/cactusbot/commands/magic/command.py
+++ b/cactusbot/commands/magic/command.py
@@ -1,6 +1,32 @@
 """Manage commands."""
 
 from . import Command
+from ..command import ROLES
+
+_ROLE_NAMES = [ROLES[role].lower() for role in ROLES]
+_REVERSED_ROLES = {v: k for k, v in ROLES.items()}
+
+
+def _role_id(role_name):
+    return _REVERSED_ROLES[role_name] if role_name in _REVERSED_ROLES else -1
+
+
+def _is_role(role):
+    return role.lower() in _ROLE_NAMES
+
+
+async def _update_role(api, command, role):
+    """Update the role of a command."""
+
+    data = {
+        "attributes": {
+            "response": {
+                "role": role
+            }
+        }
+    }
+
+    return await api.command.update(command, data)
 
 
 class Meta(Command):
@@ -91,3 +117,30 @@ class Meta(Command):
         response = await self.api.command.update_count(command, action_string)
         if response.status == 200:
             return "Count updated."
+
+    @Command.command(role="moderator")
+    async def permission(self, command: r'?command', role=None):
+        """Change the role of a command."""
+
+        if role is None:
+            # Didn't get a value, return the role of the command
+            response = await self.api.command.get(command)
+
+            if response.status == 200:
+                data = await response.json()
+                minimum_role = data["data"]["attributes"]["response"]["role"]
+                return "Minimum role for !{command} is '{role}'".format(
+                    command=command, role=ROLES[minimum_role])
+
+        valid_role = _is_role(role)
+        if not valid_role:
+            # not a real role, tell the user.
+            return "'{role}' is not a valid role!".format(role=role)
+        # Valid role, update it.
+        role_id = _role_id(role)
+        if role_id == -1:
+            return "Invalid role {}".format(role)
+        response = await _update_role(self.api, command, role)
+        if response.status == 200:
+            return "Updated role for !{command} to {role}".format(
+                command=command, role=role)

--- a/cactusbot/commands/magic/command.py
+++ b/cactusbot/commands/magic/command.py
@@ -21,10 +21,8 @@ async def _update_role(api, command, role):
     """Update the role of a command."""
 
     data = {
-        "attributes": {
-            "response": {
-                "role": role
-            }
+        "response": {
+            "role": role
         }
     }
 
@@ -140,9 +138,12 @@ class Meta(Command):
             return "'{role}' is not a valid role!".format(role=role)
         # Valid role, update it.
         role_id = _role_id(role)
+        print("STuff", role_id)
         if role_id == None:
             return "Invalid role {}".format(role)
-        response = await _update_role(self.api, command, role)
+        response = await _update_role(self.api, command, role_id)
         if response.status == 200:
             return "Updated role for !{command} to '{role}'".format(
                 command=command, role=role)
+        else:
+            return "An error occurred."

--- a/cactusbot/commands/magic/command.py
+++ b/cactusbot/commands/magic/command.py
@@ -142,5 +142,5 @@ class Meta(Command):
             return "Invalid role {}".format(role)
         response = await _update_role(self.api, command, role)
         if response.status == 200:
-            return "Updated role for !{command} to {role}".format(
+            return "Updated role for !{command} to '{role}'".format(
                 command=command, role=role)

--- a/cactusbot/commands/magic/command.py
+++ b/cactusbot/commands/magic/command.py
@@ -8,10 +8,12 @@ _REVERSED_ROLES = {v: k for k, v in ROLES.items()}
 
 
 def _role_id(role_name):
-    return _REVERSED_ROLES[role_name] if role_name in _REVERSED_ROLES else -1
+    """Get the ID of a role from the name."""
+    return _REVERSED_ROLES[role_name] if role_name in _REVERSED_ROLES else None
 
 
 def _is_role(role):
+    """Does a role name exist?"""
     return role.lower() in _ROLE_NAMES
 
 
@@ -134,11 +136,11 @@ class Meta(Command):
 
         valid_role = _is_role(role)
         if not valid_role:
-            # not a real role, tell the user.
+            # Not a real role, tell the user.
             return "'{role}' is not a valid role!".format(role=role)
         # Valid role, update it.
         role_id = _role_id(role)
-        if role_id == -1:
+        if role_id == None:
             return "Invalid role {}".format(role)
         response = await _update_role(self.api, command, role)
         if response.status == 200:

--- a/cactusbot/commands/magic/command.py
+++ b/cactusbot/commands/magic/command.py
@@ -136,14 +136,14 @@ class Meta(Command):
         if not valid_role:
             # Not a real role, tell the user.
             return "'{role}' is not a valid role!".format(role=role)
+
         # Valid role, update it.
         role_id = _role_id(role)
-        print("STuff", role_id)
-        if role_id == None:
+        if role_id is None:
             return "Invalid role {}".format(role)
+
         response = await _update_role(self.api, command, role_id)
         if response.status == 200:
             return "Updated role for !{command} to '{role}'".format(
                 command=command, role=role)
-        else:
-            return "An error occurred."
+        return "An error occurred."

--- a/docs/user/command.md
+++ b/docs/user/command.md
@@ -87,3 +87,21 @@ Otherwise, `action` may begin with either a `+` or `-`, to increase or decrease 
 [MindlessPuppetz] !command count derp +12
 [CactusBot] Count updated.
 ```
+
+## `!command role <command> [role]`
+
+Retrieve or set the `role` of a custom command.
+
+If `role` is not supplied, the current `role` is returned.
+
+```
+[EvilNotion] !command role magical
+[CactusBot] Minimum role for !magical is 'Moderator'
+```
+
+Otherwise, the role is set:
+
+```
+[HauntedKnight] !command role magical User
+[CactusBot] Updated role for !magical to 'User'
+```


### PR DESCRIPTION
## What does this change?

This adds a new command `!command permission <command> [role]` to set the role of the command.

Closes #249

### DO NOT MERGE UNTIL THE API SUPPORTS THIS! *stares at @RPiAwesomeness *

## Requirements

 - [x] Only PG-rated language used (code, commits, etc.)
 - [x] Descriptive commit messages
 - [x] Changes have been tested
 - [x] Changes do not break any existing functionalities
