### PR TITLE
Fix %ARGS% defaults.

### DIFF
--- a/cactusbot/handlers/command.py
+++ b/cactusbot/handlers/command.py
@@ -184,10 +184,10 @@ class CommandHandler(Handler):
 
             return result
 
-        if len(args) < 2 and re.search(self.ARGS_EXPR, _packet.text):
-            return MessagePacket("Not enough arguments!")
-
-        _packet.sub(self.ARGS_EXPR, sub_args)
+        if re.search(self.ARGS_EXPR, _packet.text):
+            _packet.sub(self.ARGS_EXPR, sub_args)
+            if _packet.text is "":
+                return MessagePacket("Not enough arguments!")
 
         username = ""
 

--- a/cactusbot/handlers/command.py
+++ b/cactusbot/handlers/command.py
@@ -177,6 +177,8 @@ class CommandHandler(Handler):
             if not args[1:] and default is not None:
                 result = default
             else:
+                if not args[1:]:
+                    raise IndexError
                 result = ' '.join(args[1:])
 
             if modifiers is not None:
@@ -184,10 +186,10 @@ class CommandHandler(Handler):
 
             return result
 
-        if re.search(self.ARGS_EXPR, _packet.text):
+        try:
             _packet.sub(self.ARGS_EXPR, sub_args)
-            if _packet.text == "":
-                return MessagePacket("Not enough arguments!")
+        except IndexError:
+            return MessagePacket("Not enough arguments!")
 
         username = ""
 

--- a/cactusbot/handlers/command.py
+++ b/cactusbot/handlers/command.py
@@ -1,7 +1,6 @@
 """Handle commands."""
 
 import random
-import re
 
 from ..commands import COMMANDS
 from ..commands.command import ROLES

--- a/cactusbot/handlers/command.py
+++ b/cactusbot/handlers/command.py
@@ -186,7 +186,7 @@ class CommandHandler(Handler):
 
         if re.search(self.ARGS_EXPR, _packet.text):
             _packet.sub(self.ARGS_EXPR, sub_args)
-            if _packet.text is "":
+            if _packet.text == "":
                 return MessagePacket("Not enough arguments!")
 
         username = ""

--- a/tests/handlers/test_command.py
+++ b/tests/handlers/test_command.py
@@ -84,6 +84,18 @@ def test_inject_args():
         "give"
     )
 
+    verify(
+        "Here, have some %ARGS=taco salad%!",
+        "Here, have some taco salad!",
+        "give"
+    )
+
+    verify(
+        "Here, have some %ARGS=taco salad%!",
+        "Here, have some potato salad!",
+        "give", "potato", "salad"
+    )
+
 
 def test_inject_user():
 


### PR DESCRIPTION
Fixes #247

## What does this change?

This fixes the defaults for the `%ARGS%` target.

## Requirements

 - [x] Only PG-rated language used (code, commits, etc.)
 - [x] Descriptive commit messages
 - [x] Changes have been tested
 - [x] Changes do not break any existing functionalities
