### PR TITLE
Make error messages more useful

### DIFF
--- a/cactusbot/commands/command.py
+++ b/cactusbot/commands/command.py
@@ -172,6 +172,7 @@ class Command:
                 error = err
 
         if args:
+            print("stuff things")
             return "Invalid argument: '{0}'.".format(args[0])
 
         if self.default is not None:
@@ -334,8 +335,9 @@ class Command:
 
         for index, arg in enumerate(pos_args[:len(args)]):
             if arg.annotation is not arg.empty:
-                error_response = "Invalid {type}: '{value}'.".format(
-                    type=arg.name, value=args[index])
+                argument_name = arg.name.replace('_', ' ')
+                error_response = "Invalid '{type}': '{value}'.".format(
+                    type=argument_name, value=args[index])
                 if isinstance(arg.annotation, str):
                     annotation = arg.annotation
                     if annotation.startswith('?'):

--- a/cactusbot/commands/command.py
+++ b/cactusbot/commands/command.py
@@ -172,7 +172,6 @@ class Command:
                 error = err
 
         if args:
-            print("stuff things")
             return "Invalid argument: '{0}'.".format(args[0])
 
         if self.default is not None:
@@ -200,7 +199,10 @@ class Command:
         else:
             syntax = "[{}]"
 
-        return syntax.format(arg.name)
+        argument_name = arg.name
+        if argument_name == "_":
+            argument_name = "arguments"
+        return syntax.format(argument_name)
 
     @classmethod
     def command(cls, name=None, **meta):

--- a/tests/handlers/test_command.py
+++ b/tests/handlers/test_command.py
@@ -311,3 +311,13 @@ async def test_args():
     ) == "Making potato salad with carrots, peppers."
 
     assert await potato("salad", "taco") == "TACO SALAD!?"
+
+@pytest.mark.asyncio
+async def test_list():
+    command_list = potato.commands()
+
+    assert "check" in command_list
+    assert "add" in command_list
+    assert "eat" in command_list
+    assert "wizard" in command_list
+    assert "salad" in command_list

--- a/tests/handlers/test_command.py
+++ b/tests/handlers/test_command.py
@@ -261,7 +261,7 @@ async def test_default():
     assert await potato("count") == "You have 0 potatoes."
 
     assert await potato("battery") == "Potato power!"
-    assert await potato("battery", "high") == "Invalid strength: 'high'."
+    assert await potato("battery", "high") == "Invalid 'strength': 'high'."
     assert await potato("battery", "9001") == "Potato power x 9001!"
 
     assert await potato("salad") == "Not enough arguments. <make>"


### PR DESCRIPTION
## What does this change?

Fixes #298

This turns `_` arguments into `arguments`, and makes variables with `_`'s in them, have spaces instead. Also surrounds the variables with `'`

## Requirements

 - [x] Only PG-rated language used (code, commits, etc.)
 - [x] Descriptive commit messages
 - [x] Changes have been tested
 - [x] Changes do not break any existing functionalities
